### PR TITLE
Add ability for WebGL to download from a segement of a byte array

### DIFF
--- a/StandaloneFileBrowser/Plugins/StandaloneFileBrowser.jslib
+++ b/StandaloneFileBrowser/Plugins/StandaloneFileBrowser.jslib
@@ -62,29 +62,8 @@ var StandaloneFileBrowserWebGLPlugin = {
     // byteArray: byte[]
     // byteArraySize: byte[].Length
     DownloadFile: function(gameObjectNamePtr, methodNamePtr, filenamePtr, byteArray, byteArraySize) {
-        gameObjectName = UTF8ToString(gameObjectNamePtr);
-        methodName = UTF8ToString(methodNamePtr);
-        filename = UTF8ToString(filenamePtr);
-
-        var bytes = new Uint8Array(byteArraySize);
-        for (var i = 0; i < byteArraySize; i++) {
-            bytes[i] = HEAPU8[byteArray + i];
-        }
-
-        var downloader = window.document.createElement('a');
-        downloader.setAttribute('id', gameObjectName);
-        downloader.href = window.URL.createObjectURL(new Blob([bytes], { type: 'application/octet-stream' }));
-        downloader.download = filename;
-        document.body.appendChild(downloader);
-
-        document.onmouseup = function() {
-            downloader.click();
-            document.body.removeChild(downloader);
-        	document.onmouseup = null;
-
-            SendMessage(gameObjectName, methodName);
-        }
-    }
+        DownloadFileSpan(gameObjectNamePtr, methodNamePtr, filenamePtr, byteArray, 0, byteArraySize);
+    },
 
     // Save file from span of bytes
     // DownloadFile method does not open SaveFileDialog like standalone builds, its just allows user to download file

--- a/StandaloneFileBrowser/Plugins/StandaloneFileBrowser.jslib
+++ b/StandaloneFileBrowser/Plugins/StandaloneFileBrowser.jslib
@@ -54,17 +54,6 @@ var StandaloneFileBrowserWebGLPlugin = {
         }
     },
 
-    // Save file
-    // DownloadFile method does not open SaveFileDialog like standalone builds, its just allows user to download file
-    // gameObjectNamePtr: Unique GameObject name. Required for calling back unity with SendMessage.
-    // methodNamePtr: Callback method name on given GameObject.
-    // filenamePtr: Filename with extension
-    // byteArray: byte[]
-    // byteArraySize: byte[].Length
-    DownloadFile: function(gameObjectNamePtr, methodNamePtr, filenamePtr, byteArray, byteArraySize) {
-        DownloadFileSpan(gameObjectNamePtr, methodNamePtr, filenamePtr, byteArray, 0, byteArraySize);
-    },
-
     // Save file from span of bytes
     // DownloadFile method does not open SaveFileDialog like standalone builds, its just allows user to download file
     // gameObjectNamePtr: Unique GameObject name. Required for calling back unity with SendMessage.
@@ -96,6 +85,17 @@ var StandaloneFileBrowserWebGLPlugin = {
 
             SendMessage(gameObjectName, methodName);
         }
+    },
+    
+    // Save file
+    // DownloadFile method does not open SaveFileDialog like standalone builds, its just allows user to download file
+    // gameObjectNamePtr: Unique GameObject name. Required for calling back unity with SendMessage.
+    // methodNamePtr: Callback method name on given GameObject.
+    // filenamePtr: Filename with extension
+    // byteArray: byte[]
+    // byteArraySize: byte[].Length
+    DownloadFile: function(gameObjectNamePtr, methodNamePtr, filenamePtr, byteArray, byteArraySize) {
+        this.DownloadFileSpan(gameObjectNamePtr, methodNamePtr, filenamePtr, byteArray, 0, byteArraySize);
     }
 };
 

--- a/StandaloneFileBrowser/Plugins/StandaloneFileBrowser.jslib
+++ b/StandaloneFileBrowser/Plugins/StandaloneFileBrowser.jslib
@@ -85,6 +85,39 @@ var StandaloneFileBrowserWebGLPlugin = {
             SendMessage(gameObjectName, methodName);
         }
     }
+
+    // Save file from span of bytes
+    // DownloadFile method does not open SaveFileDialog like standalone builds, its just allows user to download file
+    // gameObjectNamePtr: Unique GameObject name. Required for calling back unity with SendMessage.
+    // methodNamePtr: Callback method name on given GameObject.
+    // filenamePtr: Filename with extension
+    // byteArray: byte[] to pull a span from
+    // byteSpanStart: start index of span
+    // byteSpanSize: length of span
+    DownloadFileSpan: function(gameObjectNamePtr, methodNamePtr, filenamePtr, byteArray, byteSpanStart, byteSpanSize) {
+        gameObjectName = UTF8ToString(gameObjectNamePtr);
+        methodName = UTF8ToString(methodNamePtr);
+        filename = UTF8ToString(filenamePtr);
+
+        var bytes = new Uint8Array(byteSpanSize);
+        for (var i = 0; i < byteSpanSize; i++) {
+            bytes[i] = HEAPU8[byteArray + byteSpanStart + i];
+        }
+
+        var downloader = window.document.createElement('a');
+        downloader.setAttribute('id', gameObjectName);
+        downloader.href = window.URL.createObjectURL(new Blob([bytes], { type: 'application/octet-stream' }));
+        downloader.download = filename;
+        document.body.appendChild(downloader);
+
+        document.onmouseup = function() {
+            downloader.click();
+            document.body.removeChild(downloader);
+        	document.onmouseup = null;
+
+            SendMessage(gameObjectName, methodName);
+        }
+    }
 };
 
 mergeInto(LibraryManager.library, StandaloneFileBrowserWebGLPlugin);

--- a/StandaloneFileBrowser/Plugins/StandaloneFileBrowser.jslib
+++ b/StandaloneFileBrowser/Plugins/StandaloneFileBrowser.jslib
@@ -95,7 +95,28 @@ var StandaloneFileBrowserWebGLPlugin = {
     // byteArray: byte[]
     // byteArraySize: byte[].Length
     DownloadFile: function(gameObjectNamePtr, methodNamePtr, filenamePtr, byteArray, byteArraySize) {
-        this.DownloadFileSpan(gameObjectNamePtr, methodNamePtr, filenamePtr, byteArray, 0, byteArraySize);
+        gameObjectName = UTF8ToString(gameObjectNamePtr);
+        methodName = UTF8ToString(methodNamePtr);
+        filename = UTF8ToString(filenamePtr);
+
+        var bytes = new Uint8Array(byteArraySize);
+        for (var i = 0; i < byteArraySize; i++) {
+            bytes[i] = HEAPU8[byteArray + i];
+        }
+
+        var downloader = window.document.createElement('a');
+        downloader.setAttribute('id', gameObjectName);
+        downloader.href = window.URL.createObjectURL(new Blob([bytes], { type: 'application/octet-stream' }));
+        downloader.download = filename;
+        document.body.appendChild(downloader);
+
+        document.onmouseup = function() {
+            downloader.click();
+            document.body.removeChild(downloader);
+        	document.onmouseup = null;
+
+            SendMessage(gameObjectName, methodName);
+        }
     }
 };
 


### PR DESCRIPTION
Useful for grabbing the correct segment of a buffer, like in a MemoryStream. Avoids using ToArray on the C# end, which makes a copy.